### PR TITLE
Improve platform compatibility: Linux AppIndicator, native modules, CPU-only transformers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/
 *.log
 .env
 .env.*
+.idea
 
 # Internal project management (not for public repo)
 CLAUDE.md

--- a/scripts/build-mcp.js
+++ b/scripts/build-mcp.js
@@ -36,4 +36,9 @@ writeFileSync('out/mcp/package.json', JSON.stringify({
   }
 }, null, 2))
 
-execSync('npm install --omit=dev', { cwd: 'out/mcp', stdio: 'inherit' })
+execSync('npm install --omit=dev --onnxruntime-node-install-cuda=skip', { cwd: 'out/mcp', stdio: 'inherit' })
+
+// Rebuild native modules for Electron's Node version
+const { version: electronVersion } = require('../node_modules/electron/package.json')
+console.log(`Rebuilding MCP native modules for Electron ${electronVersion}...`)
+execSync(`npx @electron/rebuild --force --module-dir=out/mcp`, { stdio: 'inherit' })

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -70,7 +70,9 @@ function isSafeExternalUrl(raw: string): boolean {
 }
 
 function showPopover(): void {
-  if (!popoverWindow || !tray) return
+  if (!popoverWindow || !tray) {
+    return
+  }
 
   const trayBounds = tray.getBounds()
   const windowBounds = popoverWindow.getBounds()
@@ -122,7 +124,9 @@ export function showPopoverWindowFromDock(): void {
 }
 
 function togglePopover(): void {
-  if (!popoverWindow) return
+  if (!popoverWindow) {
+    return
+  }
   if (popoverWindow.isVisible()) {
     popoverWindow.hide()
   } else {
@@ -191,8 +195,15 @@ export function createTray(largeWindow?: boolean): BrowserWindow {
     { label: 'Quit', click: () => app.quit() }
   ])
 
-  tray.on('click', () => togglePopover())
-  tray.on('right-click', () => tray!.popUpContextMenu(contextMenu))
+  // On Linux, 'click' event doesn't work with GNOME AppIndicator
+  // Use setContextMenu to make tray always show popover on click
+  if (process.platform === 'linux') {
+    console.log('[Tray] Linux detected - using context menu for activation')
+    tray.setContextMenu(contextMenu)
+  } else {
+    tray.on('click', () => togglePopover())
+    tray.on('right-click', () => tray!.popUpContextMenu(contextMenu))
+  }
 
   return popoverWindow
 }


### PR DESCRIPTION
Improves platform compatibility across Linux, Windows, and environments without GPU support. Key changes include:                                                                                
                                                                                                                                                                                                           
- Native module compatibility: Added Electron rebuild step to ensure MCP native modules (like better-sqlite3) work with Electron's Node version                                                     
- Linux GNOME AppIndicator support: Fixed tray icon click behavior on Linux systems using GNOME Shell                                                                                               
- CPU-only transformers: Disabled GPU/ONNX for HuggingFace Transformers to prevent crashes in VMs or systems without GPU                                                                            
- Simplified sidecar spawning: Removed complex shell wrapper and nohup fallback on Unix, now uses Electron's bundled Node directly